### PR TITLE
Refine the debug logging a little.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -110,25 +110,19 @@ void MainWindow::on_clearOutputButton_clicked()
 }
 
 //Helper function used to handle errors that may occur
-void MainWindow::errorHandle(QProcess::ProcessError error)
+void MainWindow::errorHandle(const QProcess& failedInvocation)
 {
     //Block errors when process isn't running.  Also blocks crash error when stopProgram() is called.
     if(process->open)
     {
-        qDebug() << error;
-        switch(error)
-        {
-            case QProcess::FailedToStart:
-                ui->testOutput->appendPlainText("Test Failed to Start.");
-                ui->testOutput->appendPlainText("Check for Missing Files, and ensure you have the correct file permissions.");
-                break;
-            case QProcess::Crashed:
-                ui->testOutput->appendPlainText("Test Crashed");
-                break;
-            case QProcess::UnknownError:
-                ui->testOutput->appendPlainText("Test Started");
-                break;
-        }
+        const auto error = failedInvocation.error();
+        const QString procPath = failedInvocation.program();
+        QFileInfo fileInfo{procPath};
+        // Print some extra context
+        const auto ctxt = fileInfo.exists() ? "File exist, check permissions" : "File doesn't exist";
+        qDebug() << procPath << "\n\t" << ctxt;
+        qDebug() << "\t" << error;
+        ui->testOutput->appendPlainText("Test failed, please inspect the log.");
     }
     process->open = false; //Clears the process state variable so it can be restarted.
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -19,7 +19,7 @@
 #include <iostream>
 #include <QString>
 #include <QStringList>
-
+#include <QFileInfo>
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
 QT_END_NAMESPACE
@@ -37,7 +37,7 @@ public:
 
 public slots:
 
-    void errorHandle(QProcess::ProcessError error);
+    void errorHandle(const QProcess& failedInvocation);
 
     void printOut();
 

--- a/src/processcontroller.h
+++ b/src/processcontroller.h
@@ -44,7 +44,7 @@ public:
             // if the process reports an error -- release the lock, report error, and return appropriate error code
             connect(process, &QProcess::errorOccurred, gui, [=]()
             {
-                gui->errorHandle(process->error());
+                gui->errorHandle(*process);
             });
 
             // output handling logic


### PR DESCRIPTION
Rather than adding more context to the main output box, all logging is done to the qt debug log. Traditional output is replaced with a message to inspect Qt output